### PR TITLE
Link each mnemonic in the list to the manual

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,13 +68,13 @@
                 </ul>
                 <h4>Supported Instructions</h4>
                 <ul>
-                    <li>Immediate Arithmetic: <code>ADDIU</code>, <code>ANDI</code>, <code>ORI</code>, <code>XORI</code>, <code>SLTI</code>, <code>SLTIU</code></li>
-                    <li>Register Arithmetic: <code>ADDU</code>, <code>SUBU</code>, <code>AND</code>, <code>OR</code>, <code>XOR</code>, <code>NOR</code>, <code>SLT</code>, <code>SLTU</code></li>
-                    <li>Move: <code>MOVN</code>, <code>MOVZ</code></li>
-                    <li>Shifts: <code>SLL</code>, <code>SRL</code>, <code>SRA</code>, <code>SLLV</code>, <code>SRLV</code>, <code>SRAV</code></li>
-                    <li>Immediate Load: <code>LUI</code></li>
-                    <li>Control: <code>J</code>, <code>JR</code>, <code>JAL</code>, <code>JALR</code>, <code>BEQ</code>, <code>BNE</code>, <code>BLEZ</code>, <code>BGTZ</code>, <code>BLTZ</code>, <code>BGEZ</code></li>
-                    <li>Memory: <code>LW</code>, <code>LB</code>, <code>LBU</code>, <code>SW</code>, <code>SB</code></li>
+                    <li>Immediate Arithmetic: <a href="mips_vol2.pdf#G12.997393"><code>ADDIU</code></a>, <a href="mips_vol2.pdf#G15.997393"><code>ANDI</code></a>, <a href="mips_vol2.pdf#G110.997393"><code>ORI</code></a>, <a href="mips_vol2.pdf#G160.997393"><code>XORI</code></a>, <a href="mips_vol2.pdf#G122.997393"><code>SLTI</code></a>, <a href="mips_vol2.pdf#G123.997876"><code>SLTIU</code></a></li>
+                    <li>Register Arithmetic: <a href="mips_vol2.pdf#G13.997413"><code>ADDU</code></a>, <a href="mips_vol2.pdf#G133.997413"><code>SUBU</code></a>, <a href="mips_vol2.pdf#G14.1000988"><code>AND</code></a>, <a href="mips_vol2.pdf#G109.997713"><code>OR</code></a>, <a href="mips_vol2.pdf#G159.997701"><code>XOR</code></a>, <a href="mips_vol2.pdf#G108.997719"><code>NOR</code></a>, <a href="mips_vol2.pdf#G121.997413"><code>SLT</code></a>, <a href="mips_vol2.pdf#G124.997413"><code>SLTU</code></a></li>
+                    <li>Move: <a href="mips_vol2.pdf#G89.997389"><code>MOVN</code></a>, <a href="mips_vol2.pdf#G93.997388"><code>MOVZ</code></a></li>
+                    <li>Shifts: <a href="mips_vol2.pdf#G119.997413"><code>SLL</code></a>, <a href="mips_vol2.pdf#G128.997413"><code>SRL</code></a>, <a href="mips_vol2.pdf#G126.997413"><code>SRA</code></a>, <a href="mips_vol2.pdf#G120.997413"><code>SLLV</code></a>, <a href="mips_vol2.pdf#G129.997413"><code>SRLV</code></a>, <a href="mips_vol2.pdf#G127.997413"><code>SRAV</code></a></li>
+                    <li>Immediate Load: <a href="mips_vol2.pdf#G73.997394"><code>LUI</code></a></li>
+                    <li>Control: <a href="mips_vol2.pdf#G62.997375"><code>J</code></a>, <a href="mips_vol2.pdf#G65.997706"><code>JR</code></a>, <a href="mips_vol2.pdf#G63.997375"><code>JAL</code></a>, <a href="mips_vol2.pdf#G64.997414"><code>JALR</code></a>, <a href="mips_vol2.pdf#G26.997393"><code>BEQ</code></a>, <a href="mips_vol2.pdf#G40.997393"><code>BNE</code></a>, <a href="mips_vol2.pdf#G34.997394"><code>BLEZ</code></a>, <a href="mips_vol2.pdf#G32.997394"><code>BGTZ</code></a>, <a href="mips_vol2.pdf#G36.997394"><code>BLTZ</code></a>, <a href="mips_vol2.pdf#G28.997394"><code>BGEZ</code></a></li>
+                    <li>Memory: <a href="mips_vol2.pdf#G74.997393"><code>LW</code></a>, <a href="mips_vol2.pdf#G66.997393"><code>LB</code></a>, <a href="mips_vol2.pdf#G67.997393"><code>LBU</code></a>, <a href="mips_vol2.pdf#G134.997393"><code>SW</code></a>, <a href="mips_vol2.pdf#G113.997393"><code>SB</code></a></li>
                 </ul>
                 <p>MIPS Reference: <a href="mips_vol2.pdf">mips_vol2.pdf</a></p>
             </div>


### PR DESCRIPTION
Each mnemonic in the "Support Instructions" list is now a link to its own description page in the MIPS manual.

It might also be useful to add some sort of affordance to say "these are clickable", or even an information message that says that.

For testing, this is live at https://aperson241.github.io/mips-interpreter/.